### PR TITLE
Empty fields error fix

### DIFF
--- a/src/TranslatableFormBuilder.php
+++ b/src/TranslatableFormBuilder.php
@@ -36,7 +36,7 @@ class TranslatableFormBuilder extends FormBuilder
         $array = preg_split('/[\[\]]+/', $name, -1, PREG_SPLIT_NO_EMPTY);
         if (count($array) == 2 and in_array($array[0], Config::get('translatable::config.locales'))) {
             list($lang, $name) = $array;
-            $value = $this->model->translate($lang)->{$name};
+            $value = isset($this->model->translate($lang)->{$name}) ? $this->model->translate($lang)->{$name} : '' ;
             return $this->escapeQuotes($value);
         }
         return $this->escapeQuotes($this->model->{$name});


### PR DESCRIPTION
Sometimes when data is not available in translation table may occur error Property not exists, this fix it
